### PR TITLE
Add env example file for backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,16 @@
+# PostgreSQL connection URL
+DATABASE_URL=postgresql://USER:PASSWORD@localhost:5432/revierkompass
+
+# JWT secrets
+JWT_SECRET=your-jwt-secret
+JWT_REFRESH_SECRET=your-jwt-refresh-secret
+
+# Allowed frontend origin for CORS
+FRONTEND_URL=http://localhost:5173
+
+# Optional settings
+PORT=3001
+OSRM_URL=http://localhost:5000
+VALHALLA_URL=http://localhost:8002
+TILESERVER_URL=http://localhost:8080
+NOMINATIM_URL=http://localhost:8001


### PR DESCRIPTION
## Summary
- add `backend/.env.example` template with common variables

## Testing
- `npm run lint` *(fails: GET https://registry.npmjs.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a231fe483288ee18ffb59f879d4