### PR TITLE
Remove init scripts volume

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -270,9 +270,12 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
-volumes:
-  postgres_data:
+  volumes:
+    postgres_data:
 ```
+
+Die Datenbank wird automatisch durch Prisma-Migrationen und das Seed-Skript
+initialisiert. Zusätzliche SQL-Initialisierungsskripte sind daher nicht nötig.
 
 ## 🚨 Troubleshooting
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./init-scripts:/docker-entrypoint-initdb.d
     networks:
       - revierkompass-network
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- remove unused init-scripts volume from `backend/docker-compose.yml`
- document that database is initialized via Prisma migrations

## Testing
- `npm run lint` *(fails: GET https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a2cc05c832886d0c22190e3b889