### PR TITLE
Add basic Jest tests for backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -247,6 +247,17 @@ npm run lint        # ESLint ausführen
 npm run test        # Tests ausführen
 ```
 
+## ✅ Tests
+
+Um die Jest-Testsuite auszuführen, wechsel in das Backend-Verzeichnis und starte:
+
+```bash
+cd backend
+npm run test
+```
+
+Die Datenbankzugriffe werden dabei gemockt, sodass keine echte Datenbank benötigt wird.
+
 ## 🐳 Docker-Support
 
 ```yaml

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(test).[tj]s'],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "test": "jest",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
@@ -31,6 +32,10 @@
     "@types/node": "^20.10.4",
     "typescript": "^5.3.3",
     "tsx": "^4.6.2",
-    "prisma": "^5.7.1"
+    "prisma": "^5.7.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.10",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -142,6 +142,8 @@ const startServer = async () => {
   }
 };
 
-startServer();
+if (process.env.NODE_ENV !== 'test') {
+  startServer();
+}
 
 export default app;

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -1,0 +1,24 @@
+import request from 'supertest';
+import app from '../src/index';
+
+jest.mock('../src/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+describe('Auth routes', () => {
+  const { prisma } = require('../src/lib/prisma');
+
+  test('POST /api/auth/login returns 401 for unknown user', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'unknown@example.com', password: 'secret' });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/tests/stations.test.ts
+++ b/backend/tests/stations.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import app from '../src/index';
+
+jest.mock('../src/lib/prisma', () => ({
+  prisma: {
+    policeStation: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  },
+}));
+
+describe('Station routes', () => {
+  const { prisma } = require('../src/lib/prisma');
+
+  test('GET /api/stations returns stations array', async () => {
+    (prisma.policeStation.findMany as jest.Mock).mockResolvedValue([
+      { id: '1', name: 'Station 1' },
+    ]);
+    (prisma.policeStation.count as jest.Mock).mockResolvedValue(1);
+
+    const res = await request(app).get('/api/stations');
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.stations)).toBe(true);
+    expect(res.body.stations.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config and dev dependencies
- run app server only outside of test env
- create tests for auth and station routes
- document testing in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a331e5c8328999c485ebe88bebe