### PR TITLE
Share offline map profile definitions

### DIFF
--- a/backend/src/services/OfflineMapService.ts
+++ b/backend/src/services/OfflineMapService.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { Response } from 'express';
 import fs from 'fs/promises';
 import path from 'path';
+import { getProfileDisplayName } from '../../../shared/offline-map/profiles';
 
 interface RoutingProfile {
   mode: 'auto' | 'bicycle' | 'pedestrian' | 'bus' | 'emergency';
@@ -265,7 +266,7 @@ export class OfflineMapService {
         return {
           ...route,
           profile,
-          name: this.getProfileDisplayName(profile)
+          name: getProfileDisplayName(profile)
         };
       })
     );
@@ -483,16 +484,6 @@ export class OfflineMapService {
     return coordinates.map(coord => `${coord[1]},${coord[0]}`).join(';');
   }
 
-  private getProfileDisplayName(profile: string): string {
-    const names: Record<string, string> = {
-      emergency_fast: 'Einsatzfahrt (Schnellste)',
-      police_patrol: 'Polizei-Streife (Standard)',
-      pedestrian_safe: 'Fußweg (Sicherste)',
-      bicycle_patrol: 'Fahrrad-Streife',
-      public_transport: 'ÖPNV'
-    };
-    return names[profile] || profile;
-  }
 }
 
 export const offlineMapService = new OfflineMapService();

--- a/shared/offline-map/profiles.ts
+++ b/shared/offline-map/profiles.ts
@@ -1,0 +1,51 @@
+export const PROFILE_DISPLAY_NAMES: Record<string, string> = {
+  emergency_fast: 'Einsatzfahrt (Schnellste)',
+  police_patrol: 'Polizei-Streife (Standard)',
+  pedestrian_safe: 'Fußweg (Sicherste)',
+  bicycle_patrol: 'Fahrrad-Streife',
+  public_transport: 'ÖPNV'
+};
+
+export function getProfileDisplayName(profile: string): string {
+  return PROFILE_DISPLAY_NAMES[profile] || profile;
+}
+
+export interface DefaultRouteProfile {
+  id: string;
+  name: string;
+  mode: string;
+  costing: string;
+  description: string;
+  icon: string;
+  useCase: string;
+}
+
+export const DEFAULT_ROUTE_PROFILES: DefaultRouteProfile[] = [
+  {
+    id: 'police_patrol',
+    name: PROFILE_DISPLAY_NAMES['police_patrol'],
+    mode: 'auto',
+    costing: 'auto',
+    description: 'Standard-Routing für Polizeistreifen',
+    icon: '🚔',
+    useCase: 'Routine-Patrouillen'
+  },
+  {
+    id: 'emergency_fast',
+    name: PROFILE_DISPLAY_NAMES['emergency_fast'],
+    mode: 'emergency',
+    costing: 'auto',
+    description: 'Optimiert für Einsatzfahrten',
+    icon: '🚨',
+    useCase: 'Notfall-Einsätze'
+  },
+  {
+    id: 'pedestrian_safe',
+    name: PROFILE_DISPLAY_NAMES['pedestrian_safe'],
+    mode: 'pedestrian',
+    costing: 'pedestrian',
+    description: 'Sichere Fußwege',
+    icon: '🚶',
+    useCase: 'Fußstreife'
+  }
+];

--- a/src/lib/services/offline-map-service.ts
+++ b/src/lib/services/offline-map-service.ts
@@ -1,4 +1,5 @@
 import { toast } from 'react-hot-toast';
+import { DEFAULT_ROUTE_PROFILES } from '../../../shared/offline-map/profiles';
 
 interface NetworkStatus {
   online: boolean;
@@ -304,7 +305,7 @@ export class OfflineMapService {
         return JSON.parse(cached);
       }
       
-      return this.getDefaultProfiles();
+      return DEFAULT_ROUTE_PROFILES;
     }
   }
 
@@ -571,37 +572,6 @@ export class OfflineMapService {
     return R * c;
   }
 
-  private getDefaultProfiles(): RouteProfile[] {
-    return [
-      {
-        id: 'police_patrol',
-        name: 'Polizei-Streife (Standard)',
-        mode: 'auto',
-        costing: 'auto',
-        description: 'Standard-Routing für Polizeistreifen',
-        icon: '🚔',
-        useCase: 'Routine-Patrouillen'
-      },
-      {
-        id: 'emergency_fast',
-        name: 'Einsatzfahrt (Schnellste)',
-        mode: 'emergency',
-        costing: 'auto',
-        description: 'Optimiert für Einsatzfahrten',
-        icon: '🚨',
-        useCase: 'Notfall-Einsätze'
-      },
-      {
-        id: 'pedestrian_safe',
-        name: 'Fußweg (Sicherste)',
-        mode: 'pedestrian',
-        costing: 'pedestrian',
-        description: 'Sichere Fußwege',
-        icon: '🚶',
-        useCase: 'Fußstreife'
-      }
-    ];
-  }
 
   private calculateTileList(
     bounds: { north: number; south: number; east: number; west: number },


### PR DESCRIPTION
## Summary
- extract default route profile names into `shared/offline-map`
- use shared profile helpers in frontend and backend services

## Testing
- `npm run lint` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a48018083289cd725fd31499b6c