### PR TITLE
Add Station type definitions

### DIFF
--- a/src/types/station.types.ts
+++ b/src/types/station.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Represents a police station within the application.
+ */
+export interface Station {
+  /** Unique identifier of the station */
+  id: string;
+  /** Display name of the station */
+  name: string;
+  /** Type of the station: either police headquarters (Präsidium) or precinct (Revier) */
+  type: 'praesidium' | 'revier';
+  /** Optional: ID of the parent headquarters if this station is a precinct */
+  parentId?: string;
+  /** City in which the station is located */
+  city: string;
+  /** Postal address of the station */
+  address: string;
+  /** Geographic coordinates as [latitude, longitude] */
+  coordinates: [number, number];
+  /** Contact phone number */
+  telefon: string;
+  /** Indicates whether the station offers a 24/7 emergency service */
+  notdienst24h: boolean;
+  /** Controls visibility of the station in frontend/admin */
+  isActive: boolean;
+  /** Timestamp of the last modification (used for audit logging) */
+  lastModified: Date;
+}
+


### PR DESCRIPTION
## Summary
- add `src/types/station.types.ts` with `Station` interface

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685ce056cf2c83289d2d6b8ca3ba3657