### PR TITLE
Add Station type interface

### DIFF
--- a/src/types/station.types.ts
+++ b/src/types/station.types.ts
@@ -1,0 +1,26 @@
+export type StationType = 'praesidium' | 'revier'
+
+export interface Station {
+  /** Eindeutige Kennung der Station */
+  id: string
+  /** Name des Präsidiums oder Reviers */
+  name: string
+  /** Art der Station: Präsidium oder Revier */
+  type: StationType
+  /** Optional: ID des übergeordneten Präsidiums */
+  parentId?: string
+  /** Stadt, in der die Station liegt */
+  city: string
+  /** Vollständige Straßenadresse */
+  address: string
+  /** Koordinaten in der Form [Latitude, Longitude] */
+  coordinates: [number, number]
+  /** Telefonnummer der Station */
+  telefon: string
+  /** Rund-um-die-Uhr-Erreichbarkeit */
+  notdienst24h: boolean
+  /** Steuerung der Sichtbarkeit im Frontend oder Adminbereich */
+  isActive: boolean
+  /** Zeitpunkt der letzten Änderung (für Audit-Logs) */
+  lastModified: Date
+}


### PR DESCRIPTION
## Summary
- define central `Station` interface for praesidium/revier data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ce8685908832887b5f58b4491816d