### PR TITLE
Add Zustand stores for stations and wizard

### DIFF
--- a/src/store/useStationStore.ts
+++ b/src/store/useStationStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+import { Station } from '@/types/station.types'
+import { stationService } from '@/services/api/station.service'
+
+interface StationStore {
+  stations: Station[]
+  isLoading: boolean
+  error: string | null
+
+  loadStations: () => Promise<void>
+  getStationsByType: (type: 'praesidium' | 'revier') => Station[]
+  getReviereByPraesidium: (praesidiumId: string) => Station[]
+  getPraesidiumById: (id: string) => Station | undefined
+}
+
+export const useStationStore = create<StationStore>((set, get) => ({
+  stations: [],
+  isLoading: false,
+  error: null,
+
+  loadStations: async () => {
+    if (get().stations.length > 0 || get().isLoading) return
+    set({ isLoading: true, error: null })
+    try {
+      const data = await stationService.getAllStations()
+      set({ stations: data, isLoading: false })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      set({ error: message, isLoading: false })
+    }
+  },
+
+  getStationsByType: (type) => get().stations.filter((s) => s.type === type),
+
+  getReviereByPraesidium: (praesidiumId) =>
+    get().stations.filter((s) => s.parentId === praesidiumId),
+
+  getPraesidiumById: (id) =>
+    get().stations.find((s) => s.id === id && s.type === 'praesidium')
+}))

--- a/src/store/useWizardStore.ts
+++ b/src/store/useWizardStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+interface WizardStore {
+  currentStep: 1 | 2 | 3
+  startAddress: string
+  selectedPraesidiumId: string | null
+  selectedReviereIds: string[]
+
+  setStep: (step: 1 | 2 | 3) => void
+  setStartAddress: (address: string) => void
+  selectPraesidium: (id: string) => void
+  toggleRevier: (id: string) => void
+  resetWizard: () => void
+}
+
+export const useWizardStore = create<WizardStore>()(
+  persist(
+    (set, get) => ({
+      currentStep: 1,
+      startAddress: '',
+      selectedPraesidiumId: null,
+      selectedReviereIds: [],
+
+      setStep: (step) => set({ currentStep: step }),
+      setStartAddress: (address) => set({ startAddress: address }),
+      selectPraesidium: (id) => set({ selectedPraesidiumId: id }),
+      toggleRevier: (id) =>
+        set((state) => ({
+          selectedReviereIds: state.selectedReviereIds.includes(id)
+            ? state.selectedReviereIds.filter((r) => r !== id)
+            : [...state.selectedReviereIds, id]
+        })),
+      resetWizard: () =>
+        set({ currentStep: 1, startAddress: '', selectedPraesidiumId: null, selectedReviereIds: [] })
+    }),
+    {
+      name: 'wizard-store',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        startAddress: state.startAddress,
+        selectedPraesidiumId: state.selectedPraesidiumId,
+        selectedReviereIds: state.selectedReviereIds
+      })
+    }
+  )
+)


### PR DESCRIPTION
## Summary
- introduce `useStationStore` to load and query station data
- add `useWizardStore` to handle wizard flow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685cfb901e4083288c8bf8504ac1fe31