### PR TITLE
Implement admin API mock service and store

### DIFF
--- a/src/services/api/admin-station.service.ts
+++ b/src/services/api/admin-station.service.ts
@@ -1,0 +1,117 @@
+import { Station } from '@/types/station.types'
+import { mockStations } from './mock-data'
+
+export interface AdminStationService {
+  createStation: (
+    station: Omit<Station, 'id' | 'lastModified'>
+  ) => Promise<Station>
+  updateStation: (id: string, updates: Partial<Station>) => Promise<Station>
+  deleteStation: (id: string) => Promise<boolean>
+  toggleStationActive: (id: string) => Promise<Station>
+  bulkUpdateStations: (
+    updates: Array<{ id: string; changes: Partial<Station> }>
+  ) => Promise<Station[]>
+}
+
+const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
+const randomDelay = () => delay(100 + Math.random() * 200)
+
+let stations: Station[] = mockStations.map((s) => ({ ...s }))
+
+const generateId = () =>
+  `station_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+
+const validateParent = (parentId: string | undefined) => {
+  if (!parentId) return false
+  return stations.some((s) => s.id === parentId && s.type === 'praesidium')
+}
+
+export const adminStationService: AdminStationService = {
+  async createStation(station) {
+    await randomDelay()
+    if (station.type === 'revier' && !validateParent(station.parentId)) {
+      throw new Error('Invalid parentId for Revier')
+    }
+    const newStation: Station = {
+      ...station,
+      id: generateId(),
+      lastModified: new Date(),
+    }
+    stations = [...stations, newStation]
+    return { ...newStation }
+  },
+
+  async updateStation(id, updates) {
+    await randomDelay()
+    const index = stations.findIndex((s) => s.id === id)
+    if (index === -1) throw new Error('Station not found')
+    const current = stations[index]
+    if (
+      (updates.type === 'revier' || current.type === 'revier') &&
+      updates.parentId !== undefined &&
+      !validateParent(updates.parentId)
+    ) {
+      throw new Error('Invalid parentId for Revier')
+    }
+    const updated: Station = {
+      ...current,
+      ...updates,
+      lastModified: new Date(),
+    }
+    stations = [
+      ...stations.slice(0, index),
+      updated,
+      ...stations.slice(index + 1),
+    ]
+    return { ...updated }
+  },
+
+  async deleteStation(id) {
+    await randomDelay()
+    const index = stations.findIndex((s) => s.id === id)
+    if (index === -1) throw new Error('Station not found')
+    stations = [...stations.slice(0, index), ...stations.slice(index + 1)]
+    return true
+  },
+
+  async toggleStationActive(id) {
+    await randomDelay()
+    const index = stations.findIndex((s) => s.id === id)
+    if (index === -1) throw new Error('Station not found')
+    const updated = {
+      ...stations[index],
+      isActive: !stations[index].isActive,
+      lastModified: new Date(),
+    }
+    stations = [
+      ...stations.slice(0, index),
+      updated,
+      ...stations.slice(index + 1),
+    ]
+    return { ...updated }
+  },
+
+  async bulkUpdateStations(updates) {
+    await randomDelay()
+    const results: Station[] = []
+    for (const { id, changes } of updates) {
+      const index = stations.findIndex((s) => s.id === id)
+      if (index === -1) throw new Error(`Station not found: ${id}`)
+      if (
+        (changes.type === 'revier' || stations[index].type === 'revier') &&
+        changes.parentId !== undefined &&
+        !validateParent(changes.parentId)
+      ) {
+        throw new Error('Invalid parentId for Revier')
+      }
+      const updated: Station = {
+        ...stations[index],
+        ...changes,
+        lastModified: new Date(),
+      }
+      stations[index] = updated
+      results.push({ ...updated })
+    }
+    return results
+  },
+}

--- a/src/store/useAdminStore.ts
+++ b/src/store/useAdminStore.ts
@@ -1,0 +1,108 @@
+import { create } from 'zustand'
+import { Station } from '@/types/station.types'
+import { stationService } from '@/services/api/station.service'
+import { adminStationService } from '@/services/api/admin-station.service'
+
+interface AdminStore {
+  stations: Station[]
+  isLoading: boolean
+  error: string | null
+
+  loadStations: () => Promise<void>
+  createStation: (
+    station: Omit<Station, 'id' | 'lastModified'>
+  ) => Promise<void>
+  updateStation: (id: string, updates: Partial<Station>) => Promise<void>
+  deleteStation: (id: string) => Promise<void>
+  toggleStationActive: (id: string) => Promise<void>
+  bulkUpdateStations: (
+    updates: Array<{ id: string; changes: Partial<Station> }>
+  ) => Promise<void>
+}
+
+export const useAdminStore = create<AdminStore>((set, get) => ({
+  stations: [],
+  isLoading: false,
+  error: null,
+
+  loadStations: async () => {
+    set({ isLoading: true, error: null })
+    try {
+      const data = await stationService.getAllStations()
+      set({ stations: data, isLoading: false })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      set({ error: message, isLoading: false })
+    }
+  },
+
+  createStation: async (station) => {
+    set({ isLoading: true, error: null })
+    try {
+      const created = await adminStationService.createStation(station)
+      set({ stations: [...get().stations, created], isLoading: false })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      set({ error: message, isLoading: false })
+    }
+  },
+
+  updateStation: async (id, updates) => {
+    set({ isLoading: true, error: null })
+    try {
+      const updated = await adminStationService.updateStation(id, updates)
+      set({
+        stations: get().stations.map((s) => (s.id === id ? updated : s)),
+        isLoading: false,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      set({ error: message, isLoading: false })
+    }
+  },
+
+  deleteStation: async (id) => {
+    set({ isLoading: true, error: null })
+    try {
+      await adminStationService.deleteStation(id)
+      set({
+        stations: get().stations.filter((s) => s.id !== id),
+        isLoading: false,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      set({ error: message, isLoading: false })
+    }
+  },
+
+  toggleStationActive: async (id) => {
+    set({ isLoading: true, error: null })
+    try {
+      const updated = await adminStationService.toggleStationActive(id)
+      set({
+        stations: get().stations.map((s) => (s.id === id ? updated : s)),
+        isLoading: false,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      set({ error: message, isLoading: false })
+    }
+  },
+
+  bulkUpdateStations: async (updates) => {
+    set({ isLoading: true, error: null })
+    try {
+      const updated = await adminStationService.bulkUpdateStations(updates)
+      set({
+        stations: get().stations.map((s) => {
+          const change = updated.find((u) => u.id === s.id)
+          return change ? change : s
+        }),
+        isLoading: false,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      set({ error: message, isLoading: false })
+    }
+  },
+}))


### PR DESCRIPTION
## Summary
- add `adminStationService` with CRUD operations for station management
- create `useAdminStore` hooking to the new service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685cfdad6fcc8328865c69c84c84af25