### PR TITLE
Implement wizard store state for station selection

### DIFF
--- a/src/components/wizard/Step2TabSystemSimple.tsx
+++ b/src/components/wizard/Step2TabSystemSimple.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Users, MapPin, Plus, Edit2, Trash2, Building, ArrowRight } from 'lucide-react';
 import { useAppStore } from '@/lib/store/app-store';
+import { useWizardStore } from '@/store/useWizardStore';
 import { toast } from 'react-hot-toast';
 
 interface Station {
@@ -62,7 +63,7 @@ const Step2TabSystemSimple: React.FC = () => {
   ]);
   
   const [customAddresses, setCustomAddresses] = useState<CustomAddress[]>([]);
-  const [selectedStations, setSelectedStations] = useState<string[]>([]);
+  const { selectedStations, setSelectedStations } = useWizardStore();
   const [selectedCustom, setSelectedCustom] = useState<string[]>([]);
   const [cityFilter, setCityFilter] = useState('');
   
@@ -95,11 +96,10 @@ const Step2TabSystemSimple: React.FC = () => {
   };
 
   const handleStationToggle = (stationId: string) => {
-    setSelectedStations(prev => 
-      prev.includes(stationId)
-        ? prev.filter(id => id !== stationId)
-        : [...prev, stationId]
-    );
+    const updated = selectedStations.includes(stationId)
+      ? selectedStations.filter(id => id !== stationId)
+      : [...selectedStations, stationId];
+    setSelectedStations(updated);
   };
 
   const handleCustomToggle = (addressId: string) => {

--- a/src/store/useWizardStore.ts
+++ b/src/store/useWizardStore.ts
@@ -1,18 +1,20 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
-interface WizardStore {
-  currentStep: 1 | 2 | 3
-  startAddress: string
-  selectedPraesidiumId: string | null
-  selectedReviereIds: string[]
+  interface WizardStore {
+    currentStep: 1 | 2 | 3
+    startAddress: string
+    selectedPraesidiumId: string | null
+    selectedReviereIds: string[]
+    selectedStations: string[]
 
-  setStep: (step: 1 | 2 | 3) => void
-  setStartAddress: (address: string) => void
-  selectPraesidium: (id: string) => void
-  toggleRevier: (id: string) => void
-  resetWizard: () => void
-}
+    setStep: (step: 1 | 2 | 3) => void
+    setStartAddress: (address: string) => void
+    selectPraesidium: (id: string) => void
+    toggleRevier: (id: string) => void
+    setSelectedStations: (stations: string[]) => void
+    resetWizard: () => void
+  }
 
 export const useWizardStore = create<WizardStore>()(
   persist(
@@ -21,6 +23,7 @@ export const useWizardStore = create<WizardStore>()(
       startAddress: '',
       selectedPraesidiumId: null,
       selectedReviereIds: [],
+      selectedStations: [],
 
       setStep: (step) => set({ currentStep: step }),
       setStartAddress: (address) => set({ startAddress: address }),
@@ -31,8 +34,15 @@ export const useWizardStore = create<WizardStore>()(
             ? state.selectedReviereIds.filter((r) => r !== id)
             : [...state.selectedReviereIds, id]
         })),
+      setSelectedStations: (stations) => set({ selectedStations: stations }),
       resetWizard: () =>
-        set({ currentStep: 1, startAddress: '', selectedPraesidiumId: null, selectedReviereIds: [] })
+        set({
+          currentStep: 1,
+          startAddress: '',
+          selectedPraesidiumId: null,
+          selectedReviereIds: [],
+          selectedStations: []
+        })
     }),
     {
       name: 'wizard-store',
@@ -40,7 +50,8 @@ export const useWizardStore = create<WizardStore>()(
       partialize: (state) => ({
         startAddress: state.startAddress,
         selectedPraesidiumId: state.selectedPraesidiumId,
-        selectedReviereIds: state.selectedReviereIds
+        selectedReviereIds: state.selectedReviereIds,
+        selectedStations: state.selectedStations
       })
     }
   )


### PR DESCRIPTION
## Summary
- extend `useWizardStore` with `selectedStations` state and setter
- use `useWizardStore` in `Step2TabSystemSimple` for station selection

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d09583b68832881a7bc14187a2250