### PR TITLE
Implement Step3 store data usage

### DIFF
--- a/src/components/wizard/NoSelectionWarning.tsx
+++ b/src/components/wizard/NoSelectionWarning.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+const NoSelectionWarning: React.FC = () => (
+  <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+    <AlertTriangle className="h-12 w-12 mx-auto mb-4 opacity-50" />
+    <p>Keine Ziele ausgewählt.</p>
+    <p className="text-sm">Bitte wählen Sie Stationen oder Adressen in Schritt 2 aus.</p>
+  </div>
+);
+
+export default NoSelectionWarning;


### PR DESCRIPTION
## Summary
- use `useAppStore` and `useWizardStore` inside `Step3PremiumExport`
- add `NoSelectionWarning` component
- remove demo route generation and prepare for real data
- update maps and exports to handle missing results

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d0d5c5fac83289c5595796eb9f66e