### PR TITLE
Reset wizard state on app reset

### DIFF
--- a/backend/tests/store-reset.test.ts
+++ b/backend/tests/store-reset.test.ts
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+import { useAppStore } from '../../src/lib/store/app-store';
+import { useWizardStore } from '../../src/store/useWizardStore';
+
+describe('resetAll', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAppStore.setState({
+      wizard: {
+        currentStep: 2,
+        startAddress: null,
+        selectedCities: ['A'],
+        selectedStations: ['1'],
+        selectedCustomAddresses: ['x'],
+        routeResults: []
+      },
+      customAddresses: [{
+        id: '1',
+        name: 'Name',
+        street: '',
+        zipCode: '',
+        city: '',
+        address: '',
+        createdAt: new Date(),
+        isSelected: false
+      }]
+    } as any);
+    useWizardStore.setState({
+      selectedReviereIds: ['a'],
+      selectedStations: ['1'],
+    } as any);
+  });
+
+  test('clears both stores', () => {
+    // ensure values are set
+    expect(useWizardStore.getState().selectedReviereIds).toEqual(['a']);
+
+    useAppStore.getState().resetAll();
+
+    expect(useAppStore.getState().wizard.currentStep).toBe(1);
+    expect(useWizardStore.getState().selectedReviereIds).toEqual([]);
+  });
+});

--- a/src/lib/store/app-store.ts
+++ b/src/lib/store/app-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { useWizardStore } from '@/store/useWizardStore';
 
 // Core Interfaces
 export interface Coordinates {
@@ -180,6 +181,9 @@ export const useAppStore = create<AppState>()(
       resetAll: () => {
         // Reset Wizard State
         set({ wizard: initialWizardState });
+
+        // Reset Wizard Store persisted state
+        useWizardStore.getState().resetAll();
         
         // Reset Custom Addresses
         set({ customAddresses: [] });


### PR DESCRIPTION
## Summary
- reset wizard store state when calling `resetAll` from app store
- cover store reset behaviour with a new test

## Testing
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d60dafcc08328ac5fb2c1990fdc9d