### PR TITLE
Implement event bus for global reset

### DIFF
--- a/README_FINAL.md
+++ b/README_FINAL.md
@@ -337,6 +337,22 @@ docker-compose logs -f
 - Sicherheit durch Rate-Limiting und Validierung
 - Wartbarkeit durch modulare Architektur
 
+## 🔄 Event Bus nutzen
+
+Für das Zurücksetzen lokaler Zustände wird ein einfacher Event Bus verwendet. Die Funktionen befinden sich in `src/lib/eventBus.ts`.
+
+```ts
+import { dispatchReset, onReset } from '@/lib/eventBus';
+
+// Reset auslösen
+dispatchReset();
+
+// In Komponenten auf das Event reagieren
+useEffect(() => onReset(() => {
+  // lokale States zurücksetzen
+}), []);
+```
+
 ---
 
 ## 🎉 Erfolgreich implementiert!

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Footer from '@/components/layout/Footer';
 import WizardContainer from '@/components/wizard/WizardContainer';
 import LoginForm from '@/components/auth/LoginForm';
 import AdminDashboard from '@/components/admin/AdminDashboard';
+import { dispatchReset } from '@/lib/eventBus';
 
 function App() {
   const [currentView, setCurrentView] = useState<'wizard' | 'login' | 'admin'>('wizard');
@@ -44,7 +45,7 @@ function App() {
     resetAll();
     
     // Globales Reset-Event triggern (für lokale States in Komponenten)
-    window.dispatchEvent(new CustomEvent('revierkompass:reset'));
+    dispatchReset();
     
     // Zum Wizard mit Schritt 1 navigieren
     setCurrentView('wizard');

--- a/src/components/wizard/Step1AddressInput.tsx
+++ b/src/components/wizard/Step1AddressInput.tsx
@@ -1,13 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { MapPin, Search, Navigation, CheckCircle, ArrowRight } from 'lucide-react';
 import { useAppStore } from '@/lib/store/app-store';
 import toast from 'react-hot-toast';
+import { onReset } from '@/lib/eventBus';
 
 const Step1AddressInput: React.FC = () => {
   const [address, setAddress] = useState('');
   const [isGeocoding, setIsGeocoding] = useState(false);
   const { setStartAddress, setWizardStep, wizard } = useAppStore();
+
+  useEffect(() => onReset(() => setAddress('')), []);
 
   // Demo addresses for quick testing
   const demoAddresses = [

--- a/src/components/wizard/Step1AddressInputSimple.tsx
+++ b/src/components/wizard/Step1AddressInputSimple.tsx
@@ -1,12 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { MapPin, CheckCircle, ArrowRight } from 'lucide-react';
 import { useAppStore } from '@/lib/store/app-store';
 import { toast } from 'react-hot-toast';
+import { onReset } from '@/lib/eventBus';
 
 const Step1AddressInputSimple: React.FC = () => {
   const [address, setAddress] = useState('');
   const { setStartAddress, setWizardStep, wizard } = useAppStore();
+
+  useEffect(() => onReset(() => setAddress('')), []);
 
   // Demo addresses for quick testing
   const demoAddresses = [
@@ -168,3 +171,4 @@ const Step1AddressInputSimple: React.FC = () => {
 };
 
 export default Step1AddressInputSimple;
+

--- a/src/components/wizard/Step3PremiumExport.tsx
+++ b/src/components/wizard/Step3PremiumExport.tsx
@@ -12,6 +12,7 @@ import { routingService } from '@/lib/services/routing-service';
 import NoSelectionWarning from './NoSelectionWarning';
 import { Station as StationType } from '@/types/station.types';
 import { Station as AppStoreStation } from '@/lib/store/app-store';
+import { onReset } from '@/lib/eventBus';
 
 // Hilfsfunktion zur Konvertierung zwischen Station-Typen
 const convertStationType = (station: StationType): AppStoreStation => {
@@ -48,6 +49,17 @@ const Step3PremiumExport: React.FC = () => {
   const [isCalculating, setIsCalculating] = useState(false);
   const [exportFormat, setExportFormat] = useState<'excel' | 'pdf' | 'csv'>('excel');
   const [activeTab, setActiveTab] = useState('summary');
+
+  useEffect(
+    () =>
+      onReset(() => {
+        setRouteResults(null);
+        setIsCalculating(false);
+        setExportFormat('excel');
+        setActiveTab('summary');
+      }),
+    []
+  );
 
   useEffect(() => {
     const calculateRoutes = async () => {

--- a/src/components/wizard/UltraModernStep2.tsx
+++ b/src/components/wizard/UltraModernStep2.tsx
@@ -9,6 +9,7 @@ import { useStationStore } from '@/store/useStationStore';
 import { useWizardStore } from '@/store/useWizardStore';
 import { useAppStore } from '@/lib/store/app-store';
 import toast from 'react-hot-toast';
+import { onReset } from '@/lib/eventBus';
 
 // TypeScript-Typen
 interface Station {
@@ -123,14 +124,11 @@ const UltraModernStep2: React.FC = () => {
     // Reset beim ersten Laden
     resetOnStart();
     
-    // Globaler Reset-Event-Listener
-    const handleGlobalReset = () => {
+    // Registrierung für globalen Reset
+    const unsubscribe = onReset(() => {
       console.log('UltraModernStep2: Global reset event received');
       resetOnStart();
-    };
-    
-    // Event-Listener für globalen Reset
-    window.addEventListener('revierkompass:reset', handleGlobalReset);
+    });
     
     // Optional: Reset bei Seitenneuladeung (wenn gewünscht)
     const handleBeforeUnload = () => {
@@ -139,10 +137,10 @@ const UltraModernStep2: React.FC = () => {
     };
     
     window.addEventListener('beforeunload', handleBeforeUnload);
-    
+
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
-      window.removeEventListener('revierkompass:reset', handleGlobalReset);
+      unsubscribe();
     };
   }, [loadStations]);
   

--- a/src/lib/eventBus.ts
+++ b/src/lib/eventBus.ts
@@ -1,0 +1,12 @@
+export type ResetHandler = () => void;
+
+export const dispatchReset = (): void => {
+  window.dispatchEvent(new CustomEvent('revierkompass:reset'));
+};
+
+export const onReset = (handler: ResetHandler): (() => void) => {
+  const listener = () => handler();
+  window.addEventListener('revierkompass:reset', listener);
+  return () => window.removeEventListener('revierkompass:reset', listener);
+};
+


### PR DESCRIPTION
## Summary
- add `src/lib/eventBus.ts` module
- update `App.tsx` to dispatch reset via event bus
- register reset handlers in components with local state
- document event bus usage in README_FINAL

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d60e7c52883289b016190c5661fb6