### PR TITLE
Fix store reset and loading logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Toaster } from 'react-hot-toast';
+import { Toaster, toast } from 'react-hot-toast';
 import { useAppStore } from '@/lib/store/app-store';
 import { useAuthStore } from '@/lib/store/auth-store';
 import Header from '@/components/layout/Header';
@@ -8,7 +8,6 @@ import Footer from '@/components/layout/Footer';
 import WizardContainer from '@/components/wizard/WizardContainer';
 import LoginForm from '@/components/auth/LoginForm';
 import AdminDashboard from '@/components/admin/AdminDashboard';
-import { dispatchReset } from '@/lib/eventBus';
 
 function App() {
   const [currentView, setCurrentView] = useState<'wizard' | 'login' | 'admin'>('wizard');
@@ -40,18 +39,22 @@ function App() {
   // Zentrale Neustart-Funktion für Logo-Klick
   const handleRestart = () => {
     console.log('🔄 RevierKompass Neustart wird durchgeführt...');
-    
+
     // Alle Stores vollständig zurücksetzen
     resetAll();
-    
-    // Globales Reset-Event triggern (für lokale States in Komponenten)
-    dispatchReset();
-    
+
+    // Globales Reset-Event triggern
+    window.dispatchEvent(new CustomEvent('revierkompass:reset'));
+
     // Zum Wizard mit Schritt 1 navigieren
     setCurrentView('wizard');
     setWizardStep(1);
-    
-    console.log('✅ Neustart abgeschlossen - alle Daten zurückgesetzt');
+
+    // Kurze Verzögerung für bessere UX
+    setTimeout(() => {
+      console.log('✅ Neustart abgeschlossen - alle Daten zurückgesetzt');
+      toast.success('Anwendung erfolgreich zurückgesetzt');
+    }, 300);
   };
 
   const handleAdminLogin = () => {

--- a/src/components/wizard/UltraModernStep2.tsx
+++ b/src/components/wizard/UltraModernStep2.tsx
@@ -95,7 +95,7 @@ const UltraModernStep2: React.FC = () => {
   });
 
   // Store-Hooks
-  const { stations, getStationsByType, getReviereByPraesidium, loadStations } = useStationStore();
+  const { stations, isLoading, getStationsByType, getReviereByPraesidium, loadStations } = useStationStore();
   const { 
     customAddresses, 
     addCustomAddress, 
@@ -128,7 +128,15 @@ const UltraModernStep2: React.FC = () => {
     };
   }, [loadStations]);
 
+  useEffect(() => {
+    if (stations.length === 0 && !isLoading) {
+      console.log('UltraModernStep2: No stations loaded, loading now...');
+      loadStations();
+    }
+  }, [stations.length, isLoading, loadStations]);
+
   const resetStates = useCallback(() => {
+    console.log('UltraModernStep2: Resetting local states');
     setSearchQuery('');
     setActiveView('grid');
     setActiveTab('stations');
@@ -137,7 +145,11 @@ const UltraModernStep2: React.FC = () => {
     setShowQuickPreview(false);
     setLastSelectedId(null);
     setFormData({ name: '', street: '', zipCode: '', city: '' });
-  }, []);
+
+    // Reset auch die Store-Selektionen
+    setSelectedStations([]);
+    setSelectedCustomAddresses([]);
+  }, [setSelectedStations, setSelectedCustomAddresses]);
 
   // Memoized data
   const praesidien = useMemo(() => getStationsByType('praesidium'), [getStationsByType]);

--- a/src/lib/store/app-store.ts
+++ b/src/lib/store/app-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { useWizardStore } from '@/store/useWizardStore';
+import { useStationStore } from '@/store/useStationStore';
 
 // Core Interfaces
 export interface Coordinates {
@@ -184,7 +185,11 @@ export const useAppStore = create<AppState>()(
 
         // Reset Wizard Store persisted state
         useWizardStore.getState().resetAll();
-        
+
+        // Reset Station Store und lade neu
+        const { resetStations, loadStations } = useStationStore.getState();
+        resetStations();
+
         // Reset Custom Addresses
         set({ customAddresses: [] });
         
@@ -205,10 +210,15 @@ export const useAppStore = create<AppState>()(
         
         // Reset Error States
         set({ error: null });
-        
-        // Reset Station Data
+
+        // Reset Station Data in App Store
         set({ stations: [] });
-        
+
+        // Lade Stationen nach kurzer Verzögerung neu
+        setTimeout(() => {
+          loadStations();
+        }, 100);
+
         console.log('🔄 App Store: Vollständiger Reset durchgeführt');
       },
       

--- a/src/store/useStationStore.ts
+++ b/src/store/useStationStore.ts
@@ -8,6 +8,7 @@ interface StationStore {
   error: string | null
 
   loadStations: () => Promise<void>
+  resetStations: () => void
   getStationsByType: (type: 'praesidium' | 'revier') => Station[]
   getReviereByPraesidium: (praesidiumId: string) => Station[]
   getPraesidiumById: (id: string) => Station | undefined
@@ -19,7 +20,8 @@ export const useStationStore = create<StationStore>((set, get) => ({
   error: null,
 
   loadStations: async () => {
-    if (get().stations.length > 0 || get().isLoading) return
+    // Stations always need to be loaded when this function is called
+    if (get().isLoading) return
     set({ isLoading: true, error: null })
     try {
       const data = await stationService.getAllStations()
@@ -28,6 +30,10 @@ export const useStationStore = create<StationStore>((set, get) => ({
       const message = err instanceof Error ? err.message : 'Unknown error'
       set({ error: message, isLoading: false })
     }
+  },
+
+  resetStations: () => {
+    set({ stations: [], isLoading: false, error: null })
   },
 
   getStationsByType: (type) => get().stations.filter((s) => s.type === type),


### PR DESCRIPTION
## Summary
- allow reloading stations by adding `resetStations` and removing guard
- trigger station reload from `resetAll` in app store
- clean up wizard state properly in UltraModernStep2
- improve restart UX with toast notification

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d6cfc76d88328b14527012ee1727e